### PR TITLE
Update Dockerfile: add ssh cli for observing repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.created=$DATE \
     org.opencontainers.image.title="zeigren/phorge"
 
 RUN apk update \
-	&& apk add --no-cache bash openssh-server openssh-keygen git \
+	&& apk add --no-cache bash openssh git \
 	git-daemon subversion mercurial freetype libpng libjpeg-turbo libzip \
 	py-pygments sudo sed procps zlib imagemagick \
 	&& apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
Adding a Repository in Phorge from an existing one (i.e Bitbucket) via a ssh URL (instead of HTTPS) needs an ssh client in order to clone it.

`root` and `phuser` had no `ssh` binary available to them. I only tried this by manually running `apk add openssh`.